### PR TITLE
fix: [Easy][Fix] User info displayed in modal

### DIFF
--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -93,13 +93,13 @@ const Gallery = ({ users }: GalleryProps) => {
                   </div>
                   <div className="field">
                     <FaLocationDot className="icon" />
-                    <div className="data">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
+                    <div className="value">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
                   </div>
                   <div className="field">
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>


### PR DESCRIPTION
There is an issue with the display of user information inside the modal window.
<img width="1169" alt="Screenshot 2023-09-11 at 5 17 40 PM" src="https://github.com/ayopela3/frontend_test/assets/28190161/2e58ad38-d0ba-4bf8-a4de-ad4ae4d47331">

Some of the information is not properly aligned with where it should be. Find out what's causing this issue and fix it. 

Instructions
1. Branch out from your forked copy of fix/modal-info-display
2.Make the necessary changes and commit
3. Create a Pull Request directed to your forked copy of fix/modal-info-display
4. Provide screenshots or videos of the fixed modal info display

Solution:
- changed classname `data` to `value` to resolve indention and wrong data style on the address
- resolved alignment issue by changing `fields` to `field`

Proof:
<img width="1250" alt="task1" src="https://github.com/ayopela3/frontend_test/assets/28190161/43efca67-3f41-459b-8f31-d81beaf7cadd">
