### PR TITLE
chore: [Medium][Chore]: Improve Gallery Responsiveness

### DIFF
--- a/app/css/user-card.scss
+++ b/app/css/user-card.scss
@@ -1,6 +1,7 @@
 .user-card {
   display: flex;
   flex-flow: row nowrap;
+  min-width: 350px;
 
   padding: 16px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.07);

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -1,5 +1,5 @@
 .user-gallery {
-  width: 100%;
+  width: auto;
 
   > .items {
     display: grid;
@@ -8,6 +8,9 @@
     grid-gap: 16px;
 
     @media screen and (min-width: 768.1px) {
+      grid-template-columns: 1fr 1fr;
+    }
+    @media screen and (min-width: 1080px) {
       grid-template-columns: 1fr 1fr 1fr;
     }
   }


### PR DESCRIPTION
As a user I want to be able to view the gallery on my phone or tablet. The gallery is currently best suited for desktop devices. At smaller screen sizes it has problems fitting things into place.

Solution:
- make sure that user-gallery has an `auto` width: to support multiple display size.
- added a `min-width` of `350px` for the mobile display
- as well as changed the grid layout template on the scss file to support adjustment of display of the list.

proof:

https://github.com/ayopela3/frontend_test/assets/28190161/2f8fa76c-5d59-4d37-aed7-1b87a6d3d84c

